### PR TITLE
Some tiny performance improvements

### DIFF
--- a/penalty/Cdiff.m
+++ b/penalty/Cdiff.m
@@ -84,9 +84,7 @@ if ischar(arg.offsets)
 end
 
 if isempty(arg.offsets)
-	if ndims(kappa) == 1
-		arg.offsets = [1];
-	elseif ndims(kappa) == 2
+	if ndims(kappa) == 2
 		nx = arg.dim_i(1);
 		arg.offsets = [1 nx nx+1 nx-1]; % default 2D
 	elseif ndims(kappa) == 3

--- a/systems/@fatrix2/cat.m
+++ b/systems/@fatrix2/cat.m
@@ -11,11 +11,11 @@
 % purge any empty cells so [[]; ob] returns ob
 is_empty = cellfun(@isempty, varargin);
 if any(is_empty)
-%	varargin = {varargin{~is_empty}};
-	varargin = {varargin(~is_empty)}; % 2016-04-19
+	varargin = varargin(~is_empty); % 2016-04-19
 end
 if numel(varargin) == 1
 	ob = varargin{1};
+  return;
 end
 
 switch dim

--- a/systems/@fatrix2/mtimes.m
+++ b/systems/@fatrix2/mtimes.m
@@ -28,7 +28,11 @@ if ~isnumeric(x) % object * object
 	end
 end
 
-y = fatrix2_mtimes_vector(ob, x); % "ordinary" fatrix * vector multiplication
+if isscalar(x)
+	y = fatrix2_scalar_times(x, ob);
+else
+	y = fatrix2_mtimes_vector(ob, x); % "ordinary" fatrix * vector multiplication
+end
 
 end % mtimes()
 

--- a/systems/@fatrix2/private/fatrix2_subsref_colon.m
+++ b/systems/@fatrix2/private/fatrix2_subsref_colon.m
@@ -82,10 +82,18 @@ tmp = ob * x;
 out = zeros(size(ob,1), length(jj), class(tmp));
 out(:,1) = tmp;
 
-for nn=2:length(jj)
-	x = z;
-	x(jj(nn)) = 1;
-	out(:,nn) = ob * x;
+if ~isempty(gcp('nocreate'))
+	parfor nn=2:length(jj)
+		x = z;
+		x(jj(nn)) = 1;
+		out(:,nn) = ob * x;
+	end
+else
+	for nn=2:length(jj)
+		x = z;
+		x(jj(nn)) = 1;
+		out(:,nn) = ob * x;
+	end
 end
 
 


### PR DESCRIPTION

>(M for modified)\
M mri/mri_sensemap_denoise.m

Forcing parfor to avoid queueing sMaps estimation, which could be slow in, e.g., 32-channel case.

> M penalty/Cdiff.m

Matlab ndims()'s return always >= 2.

>M systems/@fatrix2/cat.m

Avoid nesting @fatrix2 when numel(varargin)==1

>M systems/@fatrix2/mtimes.m

Enabling A*c, where A is a @fatrix2, c is a scalar.

>M systems/@fatrix2/private/fatrix2_subsref_colon.m

Use parfor for fatrix2-matrix product, when parpool is already init'ed, (initialize a parpool can be expensive by itself, hence only use parfor when parpool is already available)

> M systems/Gmri.m

Enabling default nufft_args to support 3D;\
Substituting repmat w/ bsxfun, RAM friendly.