### PR TITLE
fix syntax error

### DIFF
--- a/mri/ir_mri_sensemap_sim.m
+++ b/mri/ir_mri_sensemap_sim.m
@@ -483,5 +483,5 @@ case 'test'
 	if im, prompt, end
 	ir_mri_sensemap_sim_test3
 otherwise
-	fail('bad argument "%s"', varargin{1})
+	fail('bad argument "%s"', arg)
 end


### PR DESCRIPTION
I'm using Matlab R2019b, and in that version, the line I changed throws an error (and it looks like a typo caused by copy-paste).