### PR TITLE
Add stack-of-spirals example with refined Pipe&Menon DCF

### DIFF
--- a/example/mri_example_3d.m
+++ b/example/mri_example_3d.m
@@ -2,63 +2,70 @@
 %|
 %| Example illustrating 3D regularized iterative reconstruction for MRI
 %| from nonuniform k-space samples.
-%| (This example does not include field inhomogeneity or relaxation.)
+%|
+%| This example does not include field inhomogeneity or relaxation
+%| or sensitivity maps.  All of those are possible extensions using
+%| existing capabilities of MIRT.
 %|
 % Copyright 2004-12-16, Jeff Fessler, University of Michigan
 
 %% create object
-% this is an "honest" simulation where the Fourier data is calculated
+% This is an "honest" simulation where the Fourier data is calculated
 % analytically from a continuous-space object model, even though the
 % reconstructions are all discrete-space.  So no "inverse crime" here.
 if ~isvar('xtrue'), printm 'setup object'
 
 	ig = image_geom('nx', 64, 'nz', 32, ...
-		'offsets', 'dsp', ... % [-n/2:n/2-1] for mri
+		'offsets', 'dsp', ... % (-n/2:n/2-1) for mri
 		'fov', [20 20 6]); % 20 cm transaxial FOV
+	iy = ceil((ig.ny+1)/2);
+	iz = ceil((ig.nz+1)/2);
 
 	xs = mri_objects('fov', ig.fovs, 'test4'); % object model
-	xtrue = xs.image(ig.xg, ig.yg, ig.zg); % samples of continuous-space
+	% samples of continuous-space, with partial volume in z:
+	xtrue = xs.image(ig.xg, ig.yg, ig.zg, 'dx', ig.dx, 'dy', ig.dy, 'dz', ig.dz);
 
-	im plc 2 3
+	im plc 3 4
 	clim = [0 1] * max(xtrue(:));
-	im(1, xtrue, 'x true', clim), cbar
+	im(xtrue, 'x true', clim), cbar
 prompt
 end
 
 
-%% k-space trajectory, k-space data
-if 1 || ~isvar('yi'), printm 'trajectory'
+%% k-space trajectory
+if ~isvar('kspace'), printm 'trajectory'
+% todo: 3d radial
 %	f.traj = 'radial';
 %	f.traj = 'cartesian';
-	f.traj = 'spiral3';
-%	f.dens = {'voronoi'};
-	f.dens = {}; % much faster than voronoi
-	cpu etic
-	[kspace, omega, wi_traj] = mri_trajectory(f.traj, {}, ig.dim, ig.fovs, f.dens);
-	cpu etoc 'trajectory setup time'
-	if 1, minmax(wi_traj), end
-	if 0, im(2, reshape(wi_traj, ig.dim)), cbar, return, end
+	f.traj = 'spiral3'; % stack-of-spirals
+	[kspace, ~, wi_simple] = mri_trajectory(f.traj, {}, ig.dim, ig.fovs, {});
 
-	if 0 && im
-		im clf; plot3(omega(:,1), omega(:,2), omega(:,3), '-.')
-		titlef('%s: %d', f.traj, size(omega,1))
+	if im % plot trajectory
+		omega = kspace .* (2*pi * ig.deltas);
+		im subplot
+		plot3(omega(:,1), omega(:,2), omega(:,3), '.')
+		titlef('%s with %d samples', f.traj, size(omega,1))
 		axis_pipi, axis square
-	return
 	end
+prompt
+end
 
+
+%% simulate k-space data
+if ~isvar('yi'), printm 'k-space data'
 	printm 'setup data, based on continuous-space object model'
 	ytrue = xs.kspace(kspace(:,1), kspace(:,2), kspace(:,3));
 
 	% add noise, if desired
 	rng(0)
 	yi = ytrue + 0 * (randn(size(ytrue)) + 1i * randn(size(ytrue)));
+	pr snr(ytrue, yi - ytrue)
 
 	dbfun = @(y) max(20*log10(abs(y) / max(abs(y(:)))), -80);
 	if streq(f.traj, 'cartesian')
-		im(4, reshape(dbfun(yi), ig.dim)), cbar
+		im(reshape(dbfun(yi), ig.dim)), cbar
 		titlef('$\log |y_i|$')
 	end
-prompt
 end
 
 
@@ -66,18 +73,18 @@ end
 if 0
 	ytmp = fftshift(fftn(fftshift(xtrue))); % cartesian
 	ytmp = ytmp * abs(ig.dx * ig.dy * ig.dz);
-	im(5, abs(ytmp), 'FFT(xtrue)'), cbar
+	im(abs(ytmp), 'FFT(xtrue)'), cbar
 
 	y3 = reshape(yi, ig.dim);
-	im(6, abs(y3-ytmp), 'fft err'), cbar
+	im(abs(y3-ytmp), 'fft err'), cbar
 	max_percent_diff(y3, ytmp)
 
 	xtmp = fftshift(ifftn(fftshift(y3)));
 	xtmp = xtmp / abs(ig.dx * ig.dy * ig.dz);
-	im(3, xtmp), cbar
+	im(xtmp), cbar
 	max_percent_diff(xtrue, xtmp)
 
-	im subplot 6
+	im subplot
 	plot(	ig.z, squeeze(xtrue(end/2+1,end/2+1,:)), '-o', ...
 		ig.z, squeeze(xtmp(end/2+1,end/2+1,:)), '-x')
 	ir_legend({'\x true', 'iFFT'})
@@ -86,36 +93,88 @@ end
 
 
 %% create Gmri object
-if ~isvar('Am'), printm 'system model'
-	printm 'setup G objects'
+if ~isvar('A3'), printm 'system model'
 	N = ig.dim;
 	nufft_args = {N, 6*ones(size(N)), 2*N, N/2, 'table', 2^10, 'minmax:kb'};
 	mask = true(N);
 	clear N
 	f.basis = {'rect'};
 %	f.basis = {'dirac*dx'};
-	Am = Gmri(kspace, mask, ...
+	A3 = Gmri(kspace, mask, ...
 		'fov', ig.fovs, 'basis', f.basis, 'nufft', nufft_args);
+end
+
+
+%% Density compensation factors (DCF)
+if ~isvar('wi_traj'), printm 'DCF'
+	if 1
+		f.dens = 'simple';
+		wi_traj = wi_simple; % fast
+	else
+%		f.dens = 'voronoi';
+		f.dens = 'pipe'; % pipe & menon
+		wi_traj = ir_mri_density_comp(kspace, f.dens, 'G', A3.arg.Gnufft, ...
+			'arg_pipe', {'fov', ig.fovs, 'niter', 60});
+	end
+	wi_max = 1.05 / prod(ig.fovs);
+	if 1, minmax(wi_traj), end
+
+	if im % plot DCF
+		nsample = size(kspace,1);
+		im subplot
+		plot([1 nsample], wi_max * [1 1], 'm-', ...
+			1:nsample, wi_traj, '.');
+		titlef('DCF')
+		xlim([1 nsample]), xtick([1 nsample])
+		legend('wi max', ['DCF ' f.dens], ...
+			'location', 'southeast'), drawnow
+	end
+
+	% trick! undo basis effect and pixel size from FT of sinc3(x/d)
+	basis_correction = prod(ig.deltas) ./ A3.arg.basis.transform;
+
+	% verify that DCF is identical for all spirals in a stack-of-spirals
+	if im && streq(f.traj, 'spiral3')
+		im subplot
+		tmp = reshape(wi_traj, [], ig.nz);
+		plot(tmp, '.'), titlef('DCFs for stack')
+	end
+prompt
+end
+
+
+%% Examine PSF of conjugate-phase reconstruction using DCF
+if ~isvar('psf3')
+	wi_basis = wi_traj ./ A3.arg.basis.transform; % trick! undo basis effect
+	psf3 = A3' * wi_basis;
+	psf3 = embed(psf3, mask);
+	im('mid3', abs(psf3), '3D PSF slices'), cbar
+
+	if im
+		im subplot
+		plot(ig.x, real(psf3(:,iy,iz)), 'b.-', ig.x, imag(psf3(:,iy,iz)), 'r.-')
+		legend('real', 'imag')
+	end
+prompt
 end
 
 
 %% Conjugate phase reconstruction
 if ~isvar('xcp'), printm 'conj. phase reconstruction'
-	minmax(Am.arg.basis.transform)
-	wi_basis = wi_traj ./ Am.arg.basis.transform; % trick! undo basis effect
+	minmax(A3.arg.basis.transform)
+	wi_basis = wi_traj ./ A3.arg.basis.transform; % trick! undo basis effect
 	minmax(wi_basis)
 
-	xcp = Am' * (wi_basis .* yi);
+	xcp = A3' * (wi_basis .* yi);
 	xcp = embed(xcp, mask);
-	im(2, xcp, 'Conj. Phase Recon'), cbar
-	minmax(xtrue)
-	minmax(xcp)
+	im(abs(xcp), '|Conj. Phase| Recon'), cbar
+	xlabelf('NRMSE = %.1f%%', 100*nrms(xcp, xtrue))
 
 	if im
-		im subplot 3
-		plot(	ig.x, squeeze(xtrue(:,end/2+1,end/2+1)), '-o', ...
-			ig.x, squeeze(real(xcp(:,end/2+1,end/2+1))), '-x')
-		ir_legend({'\x true', 'CP'})
+		im subplot
+		plot(	ig.x, squeeze(xtrue(:,iy,iz)), '.-', ...
+			ig.x, squeeze(real(xcp(:,iy,iz))), '-o')
+		ir_legend({'\x true', 'Re(CP)'}), titlef('Profiles')
 		xlabelf('x [cm]')
 	end
 prompt
@@ -124,32 +183,29 @@ end
 
 %% regularizer
 if ~isvar('R'), printm 'regularizer'
-%	beta = 2^-7 * size(omega,1); % good for quadratic 'dirac'
-	beta = 2^-21 * size(omega,1); % good for quadratic 'rect'
+%	beta = 2^-7 * size(kspace,1); % good for quadratic 'dirac'
+	beta = 2^-21 * size(kspace,1); % good for quadratic 'rect'
 	R = Reg1(ig.mask, 'beta', beta);
 	if 0 % check resolution: [1.17 1.17 1.01] for 'dirac'
-		qpwls_psf(Am, R, 1, ig.mask, 1, 'fwhmtype', 'profile');
+		qpwls_psf(A3, R, 1, ig.mask, 1, 'fwhmtype', 'profile');
 	return
 	end
 end
 
 
 %% PCG
-if ~isvar('xpcg'), printm 'PCG with quadratic penalty'
+if ~isvar('xpcg'), printm 'PCG with quadratic regularizer'
 	niter = 10;
-%	ytmp = yi / abs(ig.dx*ig.dy*ig.dz); % trick: analytical data vs DSFT
-	xpcg = qpwls_pcg1(xcp(ig.mask), Am, 1, yi(:), R.C, 'niter', niter);
+	xpcg = qpwls_pcg1(xcp(ig.mask), A3, 1, yi(:), R.C, 'niter', niter);
 	xpcg = ig.embed(xpcg);
-	im(5, xpcg, '|x| pcg quad', clim), cbar
+	im(abs(xpcg), '|PCG quad|', clim), cbar
+	xlabelf('NRMSE = %.1f%%', 100*nrms(xpcg, xtrue))
 
 	if im
-		im subplot 6
-		plot(	ig.x, squeeze(xtrue(:,end/2+1,end/2+1)), '-o', ...
-			ig.x, squeeze(real(xpcg(:,end/2+1,end/2+1))), '-+')
-		ir_legend({'\x true', 'PCG'})
+		im subplot
+		plot(	ig.x, squeeze(xtrue(:,iy,iz)), '.-', ...
+			ig.x, squeeze(real(xpcg(:,iy,iz))), '-+')
+		ir_legend({'\x true', 'Re(PCG)'}), titlef('Profiles')
 		xlabelf('x [cm]')
 	end
 end
-
-nrms(xcp, xtrue)
-nrms(xpcg, xtrue)

--- a/example/mri_stack3.m
+++ b/example/mri_stack3.m
@@ -1,0 +1,223 @@
+%% mri_stack3.m
+%|
+%| Example illustrating 3D regularized iterative reconstruction for MRI
+%| from stack-of-spirals k-space samples.
+%|
+%| This example does not include field inhomogeneity or relaxation
+%| or sensitivity maps.  All of those are possible extensions using
+%| existing capabilities of MIRT.
+%|
+%| Key components below are "kronI" for handling a stack efficiently,
+%| and precomputing the iFFT along the kz (stack) direction.
+%|
+%| For Luis, the number of slices is odd. :)
+%|
+%| Copyright 2022-08-31, Jeff Fessler, University of Michigan
+
+
+%% create object
+% This is an "honest" simulation where the Fourier data is calculated
+% analytically from a continuous-space object model, even though the
+% reconstructions are all discrete-space.  So no "inverse crime" here.
+if ~isvar('xtrue'), printm 'setup object'
+
+	ig = image_geom('nx', 64, 'nz', 17, ...
+		'offsets', 'dsp', ... % (-n/2:n/2-1) for mri
+		'fov', [20 20 5.1]); % 20 cm transaxial FOV, 3mm slices
+	fov2 = ig.fovs(1:2);
+	iy = ceil((ig.ny+1)/2);
+	iz = ceil((ig.nz+1)/2);
+
+	xs = mri_objects('fov', ig.fovs, 'test4'); % object model
+	% samples of continuous-space, with partial volume in z:
+	xtrue = xs.image(ig.xg, ig.yg, ig.zg, 'dx', ig.dx, 'dy', ig.dy, 'dz', ig.dz);
+
+	im plc 3 4
+	clim = [0 1] * max(xtrue(:));
+	im(xtrue, 'x true', clim), cbar
+prompt
+end
+
+
+%% stack-of-spirals k-space trajectory
+if ~isvar('kspace'), printm 'trajectory'
+%	ktype = 'cartesian';
+	ktype = 'spiral3';
+	[kspace2, ~, ~] = mri_trajectory(ktype, {}, ig.dim(1:2), fov2); % 2d spiral
+	nsample2 = size(kspace2,1); % # of samples in one 2d spiral
+
+	if im % plot trajectory
+		omega2 = kspace2 .* (2*pi * [ig.dx ig.dy]);
+		im subplot
+		plot(omega2(:,1), omega2(:,2), '.')
+		titlef('One spiral with %d samples', size(omega2,1))
+		axis_pipi, axis square
+	end
+
+	kz = ig.kz; % DFT sampling in kz
+	kspace      = col(repmat(kspace2(:,1), ig.nz, 1));
+	kspace(:,2) = col(repmat(kspace2(:,2), ig.nz, 1));
+	kspace(:,3) = col(repmat(kz, [nsample2 1]));
+
+	if 0 % check
+		% plot3(kspace(:,1), kspace(:,2), kspace(:,3), '-.')
+		[kspace3, omega3, wi_traj3] = mri_trajectory('spiral3', {}, ig.dim, ig.fovs, f.dens);
+		clf, plot([kspace(:,3) kspace3(:,3)])
+		max_percent_diff(kspace3, kspace), return
+	end
+prompt
+end
+
+
+%% simulate k-space data
+if ~isvar('yi_stack'), printm 'k-space data'
+	printm 'setup data, based on continuous-space object model'
+	ytrue = xs.kspace(kspace(:,1), kspace(:,2), kspace(:,3));
+	ytrue = reshape(ytrue, nsample2, ig.nz); % remind us it is a stack!
+
+	% add noise, if desired
+	rng(0)
+	yi_stack = ytrue + 0 * (randn(size(ytrue)) + 1i * randn(size(ytrue)));
+	pr snr(ytrue, yi_stack - ytrue)
+end
+
+
+%% Take IFFT in kz once and for all
+if ~isvar('yi_fftz')
+	% note: "2" is kz! and we need 1/dz for proper scaling
+	fftz = @(y) fftshift(ifft(ifftshift(y,2), [], 2), 2) / ig.dz;
+	yi_fftz = fftz(yi_stack);
+end
+
+
+%% create Gmri object
+if ~isvar('A3'), printm 'system model'
+	N = ig.dim(1:2);
+	nufft_args = {N, 6*ones(size(N)), 2*N, N/2, 'table', 2^10, 'minmax:kb'};
+	mask2 = true(N);
+	clear N
+	f.basis = {'rect'};
+%	f.basis = {'dirac*dx'};
+	A2 = Gmri(kspace2, mask2, ...
+		'fov', fov2, 'basis', f.basis, 'nufft', nufft_args);
+	A3 = kronI(ig.nz, A2); % system model for stack!
+end
+
+
+%% Density compensation factors (DCF)
+if ~isvar('wi_traj2'), printm 'DCF'
+
+	% voronoi
+	wi_voro2 = ir_mri_density_comp(kspace2, 'voronoi', 'fix_edge', 0);
+	wi_max = 1.05 / prod(fov2);
+	wi_voro2 = min(wi_voro2, wi_max);
+
+	% pipe & menon
+	wi_pipe2 = ir_mri_density_comp(kspace2, 'pipe', 'G', A2.arg.Gnufft, ...
+		'arg_pipe', {'fov', fov2, 'niter', 60});
+
+	if im % plot DCF
+		im subplot
+		plot([1 nsample2], wi_max * [1 1], 'm-', ...
+			1:nsample2, wi_voro2, '.', ...
+			1:nsample2, wi_pipe2, '.')
+		titlef('DCF for one 2D spiral')
+		xlim([1 nsample2]), xtick([1 nsample2])
+		legend('wi max', 'DCF voronoi', 'DCF Pipe', ...
+			'location', 'southeast'), drawnow
+	end
+
+	% trick! undo basis effect and pixel size from FT of sinc3(x/d)
+	basis_correction = (ig.dx * ig.dy) ./ A2.arg.basis.transform;
+
+	if im % check 2D PSF
+		psf_voro2 = embed(A2' * (basis_correction .* wi_voro2), mask2);
+		cri = @(x) cat(3, real(x), imag(x));
+		im(cri(psf_voro2))
+		xlabelf('Re(sum) is %.2f', real(sum(psf_voro2(:))))
+
+		psf_pipe2 = embed(A2' * (basis_correction .* wi_pipe2), mask2);
+		im(cri(psf_pipe2))
+		xlabelf('Re(sum) is %.2f', real(sum(psf_pipe2(:))))
+
+		im subplot
+		tmp = [psf_voro2(:,iy) psf_pipe2(:,iy)];
+		plot(ig.x, real(tmp), 'b.-', ig.x, imag(tmp), 'r.-')
+		legend('real voronoi', 'real pipe', 'imag voronoi', 'image pipe')
+	end
+
+	% use Pipe&Menon because it has better-scaled sum
+	wi_traj2 = wi_pipe2; clear wi_pipe2 wi_voro2
+prompt
+end
+
+
+%% Examine PSF of conjugate-phase reconstruction using DCF
+if ~isvar('psf3')
+	wi_basis2 = wi_traj2 ./ A2.arg.basis.transform; % trick! undo basis effect
+	fake_data = wi_basis2 .* ones(size(yi_fftz)); % broadcast!
+	fake_data = fake_data * ig.dx * ig.dy * ig.dz; % trick from FT of sinc3(x/d)
+	fake_data = fftz(fake_data);
+	psf3 = A3' * fake_data; % broadcast!
+%	psf3 = embed(psf3, ig.mask);
+	im('mid3', abs(psf3), '3D PSF slices'), cbar
+
+	if im
+		im subplot
+		plot(ig.x, real(psf3(:,iy,iz)), 'b.-', ig.x, imag(psf3(:,iy,iz)), 'r.-')
+		legend('real', 'imag')
+	end
+prompt
+end
+
+
+%% Conjugate phase reconstruction
+if ~isvar('xcp'), printm 'conj. phase reconstruction'
+	minmax(A2.arg.basis.transform)
+	wi_basis2 = wi_traj2 ./ A2.arg.basis.transform; % trick! undo basis effect
+	minmax(wi_basis2)
+
+	xcp = A3' * (wi_basis2 .* yi_fftz); % slice-wise broadcast
+%	xcp = embed(xcp, mask);
+	im(abs(xcp), '|Conj. Phase| Recon'), cbar
+	xlabelf('NRMSE = %.1f%%', 100*nrms(xcp, xtrue))
+
+	if im
+		im subplot
+		plot(	ig.x, squeeze(xtrue(:,iy,iz)), '.-', ...
+			ig.x, squeeze(real(xcp(:,iy,iz))), '-o')
+		ir_legend({'\x true', 'Re(CP)'}), titlef('Profiles')
+		xlabelf('x [cm]')
+	end
+prompt
+end
+
+
+%% regularizer
+if ~isvar('R'), printm 'regularizer'
+%	beta = 2^-7 * size(kspace,1); % good for quadratic 'dirac'
+	beta = 2^-21 * size(kspace,1); % good for quadratic 'rect'
+	R = Reg1(ig.mask, 'beta', beta * [1 1 0]); % trick: none in z!
+	if 1 % check resolution: [1.14 1.14 1] for 'rect'
+		qpwls_psf(A3, R, 1, ig.mask, 1, 'fwhmtype', 'profile');
+%	return
+	end
+end
+
+
+%% PCG
+if ~isvar('xpcg'), printm 'PCG with quadratic regularizer'
+	niter = 10;
+	xpcg = qpwls_pcg1(xcp(ig.mask), A3, 1, yi_fftz(:), R.C, 'niter', niter);
+	xpcg = ig.embed(xpcg);
+	im(abs(xpcg), '|PCG quad|', clim), cbar
+	xlabelf('NRMSE = %.1f%%', 100*nrms(xpcg, xtrue))
+
+	if im
+		im subplot
+		plot(	ig.x, squeeze(xtrue(:,iy,iz)), '.-', ...
+			ig.x, squeeze(real(xpcg(:,iy,iz))), '-+')
+		ir_legend({'\x true', 'Re(PCG)'}), titlef('Profiles')
+		xlabelf('x [cm]')
+	end
+end

--- a/fbp/image_geom.m
+++ b/fbp/image_geom.m
@@ -208,6 +208,7 @@ end
 
 meth = { ...
 	'circ', @image_geom_circ, '(rx, ry, cx, cy) [real units]'; ...
+	'deltas', @image_geom_deltas, '[dx dy (dz)]'; ...
 	'downsample', @image_geom_downsample, '()'; ...
 	'embed', @image_geom_embed, '()'; ...
 	'expand_nz', @image_geom_expand_nz, '(nz_pad)'; ...
@@ -271,6 +272,15 @@ if ~isvar('cy') || isempty(cy), cy = 0; end
 circ = ellipse_im(st, [cx cy rad1 rad2 0 1]);
 if st.is3
 	circ = repmat(circ, [1 1 st.nz]); % cylinder
+end
+
+
+% image_geom_deltas()
+function deltas = image_geom_deltas(st)
+if st.is3
+	deltas = [st.dx st.dy st.dz];
+else
+	deltas = [st.dx st.dy];
 end
 
 
@@ -641,6 +651,7 @@ st.xg + st.yg + st.zg;
 st.y';
 st.mask;
 st.circ;
+st.deltas;
 st.mask(3,4:6,1);
 size(st.maskit(repmat(st.ones, [1 1 1 3])));
 st.over(2);

--- a/graph/im.m
+++ b/graph/im.m
@@ -273,10 +273,9 @@ end
 if length(varargin) < 1, ir_usage, end
 
 if ~isempty(state.sub_m) % possibly redundant but ok
-	if state.next_sub <= state.sub_m * state.sub_n
-		im_subplot(state, state.next_sub);
-		state.next_sub = state.next_sub + 1;
-	end
+	nplot = state.sub_m * state.sub_n;
+	im_subplot(state, 1 + mod(state.next_sub-1, nplot));
+	state.next_sub = state.next_sub + 1;
 end
 
 % plotting vector(s)
@@ -722,6 +721,11 @@ function state = im_subplot(state, num)
 			ny = state.sub_m - ny - 1;
 			subplot('position', [nx*x ny*y x y])
 		else
+			if num > state.sub_m * state.sub_n
+				warn('num=%d > nsubplot=%d; resetting', ...
+					num, state.sub_m * state.sub_n)
+				num = 1;
+			end
 			subplot(state.sub_m, state.sub_n, num)
 		end
 		state.next_sub = num;

--- a/mri/mri_objects.m
+++ b/mri/mri_objects.m
@@ -508,7 +508,7 @@ out = mri_objects('rect2', rp, 'gauss2', gp);
 %
 function out = mri_objects_test4(fov, arg)
 
-cp = [0 0 0 fov(1)*0.4 fov(3)*1.0 1]; % cyl3
+cp = [0 0 0 fov(1)*0.4 fov(3)*0.8 1]; % cyl3
 
 rp = [ ... % rect3
 	-50 -50   0	40 40 40	1;
@@ -518,7 +518,7 @@ rp = [ ... % rect3
 rp(:,1:3) = rp(:,1:3)/256 .* repmat(fov, 3, 1);
 rp(:,4:6) = rp(:,4:6)/256 .* repmat(fov, 3, 1);
 
-gp = [ ...	% gauss3 bumps
+gp = [ ... % gauss3 bumps
 	-70 0 0		1 1 1	1;
 	-60 0 0		2 2 2	1;
 	-50 0 0		3 3 3	1;
@@ -614,7 +614,7 @@ prompt
 end
 
 if 1
-	st = mri_objects('fov', ig.fovs, 'test4');
+	st = mri_objects('fov', ig.fovs, 'test4'); % calls mri_objects_test4
 	xt = st.image(ig.xg, ig.yg, ig.zg);
 	im clf, im(xt), cbar
 end

--- a/mri/mri_objects.m
+++ b/mri/mri_objects.m
@@ -12,6 +12,7 @@
 %|
 %| options
 %|	'fov'	[1] | [Nd]	field of view (needed only for some tests)
+%|	'rect2half'		centered rectangle of width fov/2
 %|
 %| params:
 %|	'dirac2'	[N 3]	[xcent ycent value]
@@ -44,10 +45,20 @@ while length(varargin)
 		fov = varargin{2};
 		varargin = {varargin{3:end}};
 	case 'rect2half'
-		st = mri_objects('rect2', [0 0 fov/2 fov/2 1]);
+		if length(fov) == 1
+			fov = [fov fov];
+		elseif length(fov) ~= 2
+			fail('bad fov')
+		end
+		st = mri_objects('rect2', [0 0 fov/2 1]);
 		return
 	case 'rect3half'
-		st = mri_objects('rect3', [0 0 0 [1 1 1]*fov/2 1]);
+		if length(fov) == 1
+			fov = [fov fov fov];
+		elseif length(fov) ~= 3
+			fail('bad fov')
+		end
+		st = mri_objects('rect3', [0 0 0 fov/2 1]);
 		return
 	case 'case1'
 		st = mri_objects_case1(fov, varargin{2:end});
@@ -75,7 +86,8 @@ if is3
 		});
 else
 	st = strum(st, { ...
-		'image', @mri_objects_image2, '(x,y, [''dx'', dx, ''dy'', dy])';
+		'image', @mri_objects_image2, ...
+			'(x,y, [''dx'', dx, ''dy'', dy]) (for rect partial volume)';
 		'kspace', @mri_objects_kspace2, '(u,v)';
 		});
 end
@@ -95,7 +107,7 @@ st_types = st.types; % fix: subsref limitation
 
 out = zeros(size(x));
 
-for ii=1:length(st_types)
+for ii = 1:length(st_types)
 	params = st_params{ii};
 	switch st_types{ii}
 	case 'circ2'
@@ -122,7 +134,7 @@ st_types = st.types; % fix: subsref limitation
 
 out = zeros(size(u));
 
-for ii=1:length(st_types)
+for ii = 1:length(st_types)
 	params = st_params{ii};
 	switch st_types{ii}
 	case 'circ2'
@@ -156,7 +168,7 @@ st_types = st.types; % fix: subsref limitation
 
 out = zeros(size(x));
 
-for ii=1:length(st_types)
+for ii = 1:length(st_types)
 	params = st_params{ii};
 	switch st_types{ii}
 	case 'cyl3'
@@ -185,7 +197,7 @@ st_types = st.types; % fix: subsref limitation
 
 out = zeros(size(u));
 
-for ii=1:length(st_types)
+for ii = 1:length(st_types)
 	params = st_params{ii};
 	switch st_types{ii}
 	case 'cyl3'
@@ -217,7 +229,7 @@ out = mri_objects_image_dirac3(params, x,y,0);
 function out = mri_objects_image_dirac3(params, x,y,z)
 out = 0;
 if ncol(params) ~= 4, fail('dirac3 requires 4 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	out = out + par(4) * (x == par(1)) .* (y == par(2)) .* (z == par(3));
 end
@@ -238,7 +250,7 @@ out = mri_objects_kspace_dirac3(params, u,v,0);
 function out = mri_objects_kspace_dirac3(params, u,v,w)
 out = 0;
 if ncol(params) ~= 4, fail('dirac3 requires 4 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	out = out + par(4) * exp(-2i*pi*(u*par(1)+v*par(2)+w*par(3)));
 end
@@ -259,7 +271,7 @@ out = mri_objects_image_cyl3(params, x,y,0, 0);
 function out = mri_objects_image_cyl3(params, x,y,z, dz)
 out = 0;
 if ncol(params) ~= 6, fail('cyl3 requires 6 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -286,7 +298,7 @@ out = mri_objects_kspace_cyl3(params, u,v,0);
 function out = mri_objects_kspace_cyl3(params, u,v,w)
 out = 0;
 if ncol(params) ~= 6, fail('cyl3 requires 6 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -318,7 +330,7 @@ out = mri_objects_image_gauss3(params, x,y,0);
 function out = mri_objects_image_gauss3(params, x,y,z)
 out = 0;
 if ncol(params) ~= 7, fail('gauss3 requires 7 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -349,7 +361,7 @@ out = mri_objects_kspace_gauss3(params, u,v,0);
 function out = mri_objects_kspace_gauss3(params, u,v,w)
 out = 0;
 if ncol(params) ~= 7, fail('gauss3 requires 7 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -380,7 +392,7 @@ out = mri_objects_image_rect3(params, x,y,0, dx,dy,0);
 function out = mri_objects_image_rect3(params, x,y,z, dx,dy,dz)
 out = 0;
 if ncol(params) ~= 7, fail('rect3 requires 7 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -410,7 +422,7 @@ out = mri_objects_kspace_rect3(params, u,v,0);
 function out = mri_objects_kspace_rect3(params, u,v,w)
 out = 0;
 if ncol(params) ~= 7, fail('rect3 requires 7 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -432,7 +444,7 @@ end
 function out = mri_objects_image_sphere(params, x,y,z)
 out = 0;
 if ncol(params) ~= 5, fail('sphere requires 5 parameters'), end
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -452,7 +464,7 @@ function out = mri_objects_kspace_sphere(params, u,v,w)
 out = 0;
 if ncol(params) ~= 5, fail('sphere requires 5 parameters'), end
 s3 = sqrt(u.^2 + v.^2 + w.^2); % spherical "radial" coordinate
-for ii=1:nrow(params)
+for ii = 1:nrow(params)
 	par = params(ii,:);
 	xc = par(1);
 	yc = par(2);
@@ -507,6 +519,7 @@ out = mri_objects('rect2', rp, 'gauss2', gp);
 % mri_objects_test4()
 %
 function out = mri_objects_test4(fov, arg)
+assert(all(size(fov) == [1 3])) % fov must be 1x3
 
 cp = [0 0 0 fov(1)*0.4 fov(3)*0.8 1]; % cyl3
 
@@ -515,8 +528,8 @@ rp = [ ... % rect3
 	 50 -50  40	20 20 50	1;
 	  0  50 -40	30 30 60	1;
 ];
-rp(:,1:3) = rp(:,1:3)/256 .* repmat(fov, 3, 1);
-rp(:,4:6) = rp(:,4:6)/256 .* repmat(fov, 3, 1);
+rp(:,1:3) = rp(:,1:3)/256 .* fov;
+rp(:,4:6) = rp(:,4:6)/256 .* fov;
 
 gp = [ ... % gauss3 bumps
 	-70 0 0		1 1 1	1;
@@ -528,8 +541,8 @@ gp = [ ... % gauss3 bumps
 	20 0 0		7 7 7	1;
 	50 0 0		8 8 8	1;
 ];
-gp(:,1:3) = gp(:,1:3)/256 .* repmat(fov, 8, 1);
-gp(:,4:6) = gp(:,4:6)/256 .* repmat(fov, 8, 1);
+gp(:,1:3) = gp(:,1:3)/256 .* fov;
+gp(:,4:6) = gp(:,4:6)/256 .* fov;
 
 if isvar('arg') && streq(arg, 'cm')
 	rp(:,1:6) = rp(:,1:6) / 10;
@@ -543,17 +556,17 @@ out = {'cyl3', cp, 'rect3', rp, 'gauss3', gp};
 % 2d tests
 %
 function mri_objects_test2
-ig = image_geom('nx', 2^7, 'ny', 2^7+2, 'offsets', 'dsp', 'dx', 4);
+ig = image_geom('nx', 2^7, 'ny', 2^7+2, 'offsets', 'dsp', 'dx', 5, 'dy', 4);
 
 if 1 % test transforms of each object type
 	shift = [0.1 0.2] .* ig.fovs;
-	sizes = [0.15 0.1] .* ig.fovs;
+	sizes = [0.16 0.1] .* ig.fovs;
 	tests = {'circ2', [shift sizes(1) 2];
 		'gauss2', [shift sizes 2];
 		'rect2', [shift sizes 2];
 		};
-	im plc 3 3
-	for ii=1:nrow(tests)
+	im plc 3 5
+	for ii = 1:nrow(tests)
 		otype = tests{ii,1};
 		param = tests{ii,2};
 		st = mri_objects(otype, param);
@@ -564,9 +577,15 @@ if 1 % test transforms of each object type
 		f2 = st.kspace(fg{:});
 		max_percent_diff(f2, s2, otype)
 
-		im(1+3*(ii-1), i2, otype), cbar
-		im(2+3*(ii-1), abs(s2), 'fft'), cbar
-		im(3+3*(ii-1), abs(f2), 'kspace'), cbar
+		r2 = ifftshift(ifftn(fftshift(f2))) * ...
+			(ig.u(2) - ig.u(1)) * (ig.v(2) - ig.v(1)) * prod(ig.dim);
+
+		im(1+5*(ii-1), i2, otype), cbar
+		im(2+5*(ii-1), abs(s2), 'fft'), cbar
+		im(3+5*(ii-1), abs(f2), 'kspace'), cbar
+		im(4+5*(ii-1), abs(r2), 'recon'), cbar
+		im(5+5*(ii-1), abs(r2 - i2), 'err'), cbar
+		assert(norm(r2-i2) / norm(i2) < 5e-2)
 	end
 prompt
 end
@@ -595,7 +614,7 @@ if 1 % test transforms of each object type
 		};
 
 	im plc 4 3
-	for ii=1:nrow(tests)
+	for ii = 1:nrow(tests)
 		otype = tests{ii,1};
 		param = tests{ii,2};
 		st = mri_objects(otype, param);

--- a/mri/mri_trajectory.m
+++ b/mri/mri_trajectory.m
@@ -170,7 +170,12 @@ end
 % mri_trajectory_stack()
 % make 3D "stack of ..." trajectory from a 2D trajectory
 function omega = mri_trajectory_stack(omega2, N3)
-o3 = single([0:(N3-1)]/N3 - 0.5)*2*pi;
+if mod(N3,2) == 0 % iseven
+	o3 = ((0:(N3-1))/N3 - 0.5);
+else % isodd
+	o3 = (-(N3-1)/2 : (N3-1)/2) / N3;
+end
+o3 = single(o3 * 2 * pi);
 o3 = repmat(o3, nrow(omega2), 1); % [N12,N3]
 omega = repmat(omega2, N3, 1); % [N12*N3,2]
 omega = [omega o3(:)]; % [N12*N3,3]

--- a/utilities/private/jf_mid3.m
+++ b/utilities/private/jf_mid3.m
@@ -1,25 +1,53 @@
-function out = jf_mid3(pn, zz, dim)
-% extract middle slices in all 3 dimensions of 3d array 'zz'
-% or the middle slice from dimension 'dim'
+ function out = jf_mid3(pn, zz, dim)
+%function out = jf_mid3(pn, zz, dim)
+%|
+%| Extract "middle" slices in all 3 dimensions of 3d array 'zz'
+%| or the middle slice from dimension 'dim'.
+%| For an even-sized dimension, it uses slice n/2+1 (per FFT), as of 2022-08-31.
+
 if nargin < 2, ir_usage, end
+
+if streq(zz, 'test'), jf_mid3_test(pn); out = []; return, end
+
+assert(ndims(zz) == 3)
+[nx, ny, nz] = size(zz);
+
+%jf_mid3_fun = @(n) ceil(n/2); % before 2022-08-31
+jf_mid3_fun = @(n) ceil((n+1)/2);
+i1 = jf_mid3_fun(nx);
+i2 = jf_mid3_fun(ny);
+i3 = jf_mid3_fun(nz);
 
 if nargin > 2 && ~isempty(dim)
 	nn = size(zz, dim);
 	switch dim
 	case 1
-		out = zz(ceil(end/2),:,:);
+		out = zz(i1,:,:);
 	case 2
-		out = zz(:,ceil(end/2),:);
+		out = zz(:,i2,:);
 	case 3
-		out = zz(:,:,ceil(end/2));
+		out = zz(:,:,i3);
 	otherwise
 		fail('bad dim %d', dim)
 	end
 return
 end
 
-nz = size(zz,3);
-xy = zz(:,:,ceil(end/2));
-xz = permute(zz(:,ceil(end/2),:), [1 3 2]);
-zy = permute(zz(ceil(end/2),:,:), [2 3 1])';
-out = [ xy, xz; zy, zeros(nz,nz)];
+xy = zz(:,:,i3);
+xz = permute(zz(:,i2,:), [1 3 2]);
+zy = permute(zz(i1,:,:), [2 3 1])';
+out = [xy, xz; zy, zeros(nz,nz)];
+end
+
+
+function jf_mid3_test(pn)
+	x = rand(3,4,5);
+	y = jf_mid3(pn, x);
+	assert(all(size(y) == [8 9]))
+	y = jf_mid3(pn, x, 1);
+	assert(all(y == x(2,:,:), 'all'))
+	y = jf_mid3(pn, x, 2);
+	assert(all(y == x(:,3,:), 'all'))
+	y = jf_mid3(pn, x, 3);
+	assert(all(y == x(:,:,3), 'all'))
+end

--- a/utilities/reale.m
+++ b/utilities/reale.m
@@ -3,7 +3,7 @@
 %function y = reale(x, arg2, arg3)
 %|
 %| y = reale(x)
-%| y = reale(x, tol)
+%| y = reale(x, tol) [default tol is 1e-13 for double, else 1e-6]
 %| y = reale(x, 'warn', 'message')
 %| y = reale(x, 'error')
 %| y = reale(x, 'report')


### PR DESCRIPTION
Many changes here:
- New `mri_stack3` example
- Refined Pipe & Menon DCF in `ir_mri_density_comp`
- Corrected handling of odd image sizes in `image_geom` and `jf_mid3`
- Added `.deltas` `.offsets` `.kz` methods to `image_geom`
- Improved `subplot` in `im`
- Non-square FOV in some places including `mri_objects` and `mri_trajectory`