### PR TITLE
Update ir_mex_build to build penalty_mex file

### DIFF
--- a/ir_mex_build.m
+++ b/ir_mex_build.m
@@ -12,5 +12,6 @@
 
 ir_mex_build_mri
 ir_mex_build_table
+irt_mex_make
 
 % todo: ir_mex_build_penal

--- a/mex/local/readme.txt
+++ b/mex/local/readme.txt
@@ -1,0 +1,5 @@
+mex/local/readme.txt
+
+This directory contains MEX files that are compiled locally by the user,
+typically by running (from the top-level MIRT directory) the m-function
+>> ir_mex_build

--- a/mex/src/irt_mex_make.m
+++ b/mex/src/irt_mex_make.m
@@ -7,7 +7,6 @@ if ispc
 	cd ../../..
 else
 	cd mex/src/penalty
-	% mex -v penalty_mex.c mexarg.c 'penalty,diff.c' -DMmex -outdir ../v7
-    mex -v penalty_mex.c '../def/mexarg.c' 'penalty,diff.c' -I'../def/' -DMmex -outdir ../..
+    mex -v penalty_mex.c '../def/mexarg.c' 'penalty,diff.c' -I'../def/' -DMmex -outdir ../../local
 	cd ../../..
 end

--- a/mex/src/irt_mex_make.m
+++ b/mex/src/irt_mex_make.m
@@ -3,11 +3,11 @@
 if ispc
 	cd mex/src/penalty
 	% mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../v7
-    mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../
+    mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../..
 	cd ../../..
 else
 	cd mex/src/penalty
 	% mex -v penalty_mex.c mexarg.c 'penalty,diff.c' -DMmex -outdir ../v7
-    mex -v penalty_mex.c '../def/mexarg.c' 'penalty,diff.c' -I'../def/' -DMmex -outdir ../
+    mex -v penalty_mex.c '../def/mexarg.c' 'penalty,diff.c' -I'../def/' -DMmex -outdir ../..
 	cd ../../..
 end

--- a/mex/src/irt_mex_make.m
+++ b/mex/src/irt_mex_make.m
@@ -2,8 +2,7 @@
 
 if ispc
 	cd mex/src/penalty
-	% mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../v7
-    mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../..
+    mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../../local
 	cd ../../..
 else
 	cd mex/src/penalty

--- a/mex/src/irt_mex_make.m
+++ b/mex/src/irt_mex_make.m
@@ -1,11 +1,13 @@
 % irt_mex_make.m
 
 if ispc
-	cd penalty
-	mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../v7
-	cd ..
+	cd mex/src/penalty
+	% mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../v7
+    mex penalty_mex.c mexarg.c 'penalty,diff.c' -DIs_pc -DMmex -outdir ../
+	cd ../../..
 else
-	cd penalty
-	mex -v penalty_mex.c mexarg.c 'penalty,diff.c' -DMmex -outdir ../v7
-	cd ..
+	cd mex/src/penalty
+	% mex -v penalty_mex.c mexarg.c 'penalty,diff.c' -DMmex -outdir ../v7
+    mex -v penalty_mex.c '../def/mexarg.c' 'penalty,diff.c' -I'../def/' -DMmex -outdir ../
+	cd ../../..
 end

--- a/setup.m
+++ b/setup.m
@@ -29,6 +29,11 @@ if irtdir(end) ~= filesep % make sure there is a '/' at end of directory
 	irtdir = [irtdir filesep];
 end
 
+if ~exist([irtdir 'mex/local'], 'dir')
+    disp(sprintf('The directory "%s" does not exist. Creating it now.', [irtdir 'mex/local']))
+    mkdir([irtdir 'mex/local']);
+end
+
 list = {...
 'align', ...		% image registration
 'align/mex', ...	% image registration mex files
@@ -74,6 +79,8 @@ end
 % Much of the toolbox will work without mex, just slower.
 addpath([irtdir 'mex/local']) % must precede "mex/v7"
 addpath([irtdir 'mex/v7']);
+
+disp('NOTE: Previous irt versions expected MEX files in "mex/v7".')
 
 % do not add the paths below if you are using Matlab!
 if ir_is_octave

--- a/setup.m
+++ b/setup.m
@@ -29,10 +29,6 @@ if irtdir(end) ~= filesep % make sure there is a '/' at end of directory
 	irtdir = [irtdir filesep];
 end
 
-if ~exist([irtdir 'mex/local'], 'dir')
-    disp(sprintf('The directory "%s" does not exist. Creating it now.', [irtdir 'mex/local']))
-    mkdir([irtdir 'mex/local']);
-end
 
 list = {...
 'align', ...		% image registration

--- a/setup.m
+++ b/setup.m
@@ -72,7 +72,8 @@ end
 % e.g., 7.3 and running on earlier 7.0 won't work.
 % If you have mex problems, comment out the following line.
 % Much of the toolbox will work without mex, just slower.
-% addpath([irtdir 'mex/v7']);
+addpath([irtdir 'mex/local']) % must precede "mex/v7"
+addpath([irtdir 'mex/v7']);
 
 % do not add the paths below if you are using Matlab!
 if ir_is_octave

--- a/setup.m
+++ b/setup.m
@@ -41,6 +41,8 @@ list = {...
 'fbp', ...		% FBP (filtered backprojection) code
 'general', ...		% generic image reconstruction
 'graph', ...		% graphics routines
+'mex', ...      % MEX files
+'mex/src', ...  % MEX source code
 'mri', ...		% MRI reconstruction
 'mri/fieldmap', ...	% MRI B0 field map estimation
 'mri-rf/yip-spsp', ...	% MRI RF pulse design
@@ -71,9 +73,6 @@ end
 % If you have mex problems, comment out the following line.
 % Much of the toolbox will work without mex, just slower.
 % addpath([irtdir 'mex/v7']);
-
-% Set up path to mex source files
-addpath([irtdir 'mex/src']);
 
 % do not add the paths below if you are using Matlab!
 if ir_is_octave

--- a/setup.m
+++ b/setup.m
@@ -76,7 +76,6 @@ end
 addpath([irtdir 'mex/local']) % must precede "mex/v7"
 addpath([irtdir 'mex/v7']);
 
-disp('NOTE: Previous irt versions expected MEX files in "mex/v7".')
 
 % do not add the paths below if you are using Matlab!
 if ir_is_octave

--- a/setup.m
+++ b/setup.m
@@ -70,8 +70,10 @@ end
 % e.g., 7.3 and running on earlier 7.0 won't work.
 % If you have mex problems, comment out the following line.
 % Much of the toolbox will work without mex, just slower.
-addpath([irtdir 'mex/v7']);
+% addpath([irtdir 'mex/v7']);
 
+% Set up path to mex source files
+addpath([irtdir 'mex/src']);
 
 % do not add the paths below if you are using Matlab!
 if ir_is_octave

--- a/setup.m
+++ b/setup.m
@@ -41,8 +41,8 @@ list = {...
 'fbp', ...		% FBP (filtered backprojection) code
 'general', ...		% generic image reconstruction
 'graph', ...		% graphics routines
-'mex', ...      % MEX files
-'mex/src', ...  % MEX source code
+'mex/local', ... % MEX files compiled for local OS/CPU
+'mex/src', ... % MEX source code for irt_mex_make.m
 'mri', ...		% MRI reconstruction
 'mri/fieldmap', ...	% MRI B0 field map estimation
 'mri-rf/yip-spsp', ...	% MRI RF pulse design


### PR DESCRIPTION
Description of changes:

1. Added `mex/` to MATLAB path in `setup.m` to ensure mex source files are available
2. Added `irt_mex_make` to `ir_mex_build.m` so it is run as part of standard build
3. Updated directory handling in `irt_mex_make` so the script runs when called from `ir_mex_build`
_Note_: this means there would be an error when running `irt_mex_make `from the `mex/src` directory, so there might be a more elegant solution
4. Edited `mex` build command for `penalty_mex` to reflect current directory structure. Note that it no longer saves to the `mex/v7` folder.