### PR TITLE
Add mex/local/ directory

### DIFF
--- a/mex/local/readme.txt
+++ b/mex/local/readme.txt
@@ -1,0 +1,5 @@
+mex/local/readme.txt
+
+This directory contains MEX files that are compiled locally by the user,
+typically by running (from the top-level MIRT directory) the m-function
+>> ir_mex_build


### PR DESCRIPTION
Add `mex/local/` directory (empty except for `readme.txt`) so that it will always be there for building local mex files, e.g., via `ir_mex_build`.